### PR TITLE
JS1 problem 4: Add a test case for non-Boolean return values

### DIFF
--- a/js1/__tests__/4.js
+++ b/js1/__tests__/4.js
@@ -19,4 +19,12 @@ describe('call with increasing numbers', () => {
     })
     expect(calls).toEqual([0, 1, 2, 3, 4, 5])
   })
+  it('should call function 4 times (handle non-Boolean return values)', () => {
+    let calls = []
+    solution((e) => {
+      calls.push(e)
+      return e < 3 ? 0 : false
+    })
+    expect(calls).toEqual([0, 1, 2, 3])
+  })
 })


### PR DESCRIPTION
This adds a test case which could catch solutions that do not use strict
equality comparison.