### PR TITLE
js02: tests: add callbacks to prototype method calls

### DIFF
--- a/js2/__tests__/10.js
+++ b/js2/__tests__/10.js
@@ -20,7 +20,7 @@ describe('test cFilter', () => {
     expect(a).toEqual([1, 2, 3])
   })
   it('should return [] for []', () => {
-    expect([].cFilter()).toEqual([])
+    expect([].cFilter(cb)).toEqual([])
   })
   it('should return every element if filter is always true', () => {
     const a = [1, 2, 3]

--- a/js2/__tests__/8.js
+++ b/js2/__tests__/8.js
@@ -20,7 +20,7 @@ describe('test gsMap', () => {
     expect(a).toEqual([1, 2, 3])
   })
   it('should return [] for []', () => {
-    expect([].cMap()).toEqual([])
+    expect([].cMap(cb)).toEqual([])
   })
   it('should return new array of 3 elements increased by the value of its index', () => {
     const a = [1, 2, 3]


### PR DESCRIPTION
- Calling `Array.prototype` methods like `map`, `forEach`, `filter`, and `find` without a callback throws a `TypeError`
- The tests for challenges 8 and 10 call the prototype methods `cMap` and `cFilter` without callbacks (when testing with empty arrays)
- When there are no callbacks, any solutions that faithfully replicate these prototype methods (throw `TypeError`s for missing callbacks) will fail the tests
- This commit adds callbacks to these method calls
- Adding the callbacks will not affect solutions that do not throw `TypeError`s for missing callbacks