### PR TITLE
js03c03: test: ensure solution uses hasOwnProperty

### DIFF
--- a/js3/__tests__/3.js
+++ b/js3/__tests__/3.js
@@ -34,4 +34,20 @@ describe('given an array of strings, invoking the returned function returns an o
     const result2 = fn({ 'sports': 'basketball', 'work2': 'software engineering' })
     expect(result2).toEqual({ 'sports': 'basketball' })
   })
+
+  it('should not consider properties from the object\'s prototype chain', () => {
+    const obj = { a: 1, b: 2 };
+    const arr = ['hasOwnProperty'];
+    const expected = {};
+    const returnedFunc = solution(arr);
+    expect(returnedFunc(obj)).toEqual({});
+  });
+
+  it('should not exclude properties with falsy values', () => {
+    const obj = { a: 0, b: 2 };
+    const arr = ['a'];
+    const expected = { a: 0 };
+    const returnedFunc = solution(arr);
+    expect(returnedFunc(obj)).toEqual(expected);
+  });
 })


### PR DESCRIPTION
Add tests for conditions where using the property accessor instead of `Object.prototype.hasOwnProperty` will cause:

- incorrect properties to be included from returned object
- correct properties to be excluded from returned object