### PR TITLE
JS2 problem 9: Add a test case where there is no initial accumulator

### DIFF
--- a/js2/__tests__/9.js
+++ b/js2/__tests__/9.js
@@ -41,14 +41,11 @@ describe('test cReduce', () => {
     const b = { bob: true, obo: false, boo: true }
     expect(a.cReduce(cb, {})).toEqual(b)
   })
-
-  it('should reduce the elements of [1,2,3,4] to 10', () => {
+  it('should reduce the elements of [1,2,3,4] to 10 (no initial accumulator)', () => {
     const cb = (ac, cv) => {
       return ac + cv
     }
     const test = [1, 2, 3, 4]
     expect(test.cReduce(cb)).toEqual(10)
-
   })
-
 })


### PR DESCRIPTION
To match with the expectation of JavaScript's native reduce() function,
this adds a test case which doesn't pass initial accumulator.