### PR TITLE
Fix/interview js5 test suite

### DIFF
--- a/interviews/__tests__/5.js
+++ b/interviews/__tests__/5.js
@@ -17,7 +17,7 @@ describe('should find mininum time to run tasks', () => {
     const result = solution(a);
     expect(result).to.equal(5);
   });
-  it.only('should handle non-greedy case', () => {
+  it('should handle non-greedy case', () => {
     const a = [5,4,3,3,3,3,3,3];
     const result = solution(a);
     expect(result).to.equal(9);


### PR DESCRIPTION
When you run:
```bash
npm run test -- interviews/__tests__/5.js
```
The test suite skips the other tests:
```bash
Test Suites: 1 failed, 1 total
Tests:       1 failed, 3 skipped, 4 total
Snapshots:   0 total
Time:        0.719 s, estimated 1 s
```
The problem is the 4th test that are using [.only()](https://jestjs.io/docs/en/api#testonlyname-fn-timeout).

```javascript
it.only('should handle non-greedy case', () => {
  ...  
});
```