### PR TITLE
js2 problem 9: Add a test case that reduces strings

### DIFF
--- a/js2/__tests__/9.js
+++ b/js2/__tests__/9.js
@@ -51,4 +51,12 @@ describe('test cReduce', () => {
 
   })
 
+  it('should reduce ["1", "2", "3"] to "123"', () => {
+    const cb = (ac, cv) => {
+      return ac + cv
+    }
+    const a = ['1', '2', '3']
+    const b = '123'
+    expect(a.cReduce(cb)).toEqual(b)
+  })
 })


### PR DESCRIPTION
This test case would catch common errors of providing number 0 as the
default initial value.