### PR TITLE
Remove single-argument cReduce tests in js2/9

### DIFF
--- a/js2/__tests__/9.js
+++ b/js2/__tests__/9.js
@@ -41,22 +41,12 @@ describe('test cReduce', () => {
     const b = { bob: true, obo: false, boo: true }
     expect(a.cReduce(cb, {})).toEqual(b)
   })
-
-  it('should reduce the elements of [1,2,3,4] to 10', () => {
-    const cb = (ac, cv) => {
-      return ac + cv
-    }
-    const test = [1, 2, 3, 4]
-    expect(test.cReduce(cb)).toEqual(10)
-
-  })
-
   it('should reduce ["1", "2", "3"] to "123"', () => {
     const cb = (ac, cv) => {
       return ac + cv
     }
     const a = ['1', '2', '3']
     const b = '123'
-    expect(a.cReduce(cb)).toEqual(b)
+    expect(a.cReduce(cb, '')).toEqual(b)
   })
 })


### PR DESCRIPTION
- The reason why we're removing the single-argument cReduce tests is because the cReduce descriptions says:
"It is best practice to pass in 2 arguments into reduce function. Therefore, for this challenge, you can assume that when your function, cReduce, will always be called with 2 arguments: a function and initial value."
- See the description for cReduce at: https://www.c0d3.com/curriculum/js2?challenge=129